### PR TITLE
CON-618 Add an example of each type of eip:155 supported transaction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,7 +81,7 @@ function App() {
               />
             </label>
             <label>
-              Hedera Testnet Private Key:
+              Hedera Testnet ECDSA Hex Private Key:
               <input
                 type="password"
                 value={privateKey}

--- a/src/lib/eip155-wallet.ts
+++ b/src/lib/eip155-wallet.ts
@@ -94,11 +94,16 @@ export default class EIP155Wallet implements EIP155WalletInterface {
   eth_signTypedData_v4(domain: any, types: any, data: any): Promise<string> {
     return this.eth_signTypedData(domain, types, data);
   }
-  async eth_signTransaction(transaction: JsonRpcTransactionRequest, provider: JsonRpcProvider): Promise<string> {
+  async eth_signTransaction(
+    transaction: JsonRpcTransactionRequest,
+    provider: JsonRpcProvider,
+  ): Promise<string> {
     console.log({ transaction });
 
     // Populate transaction
-    const preparedTransaction = await this.connect(provider).populateTransaction(transaction as TransactionRequest);
+    const preparedTransaction = await this.connect(
+      provider,
+    ).populateTransaction(transaction as TransactionRequest);
     delete preparedTransaction.from;
     const txObj = Transaction.from(preparedTransaction);
 
@@ -108,7 +113,9 @@ export default class EIP155Wallet implements EIP155WalletInterface {
     transaction: JsonRpcTransactionRequest,
     provider: JsonRpcProvider,
   ): Promise<TransactionResponse> {
-    return this.connect(provider).sendTransaction(transaction as TransactionRequest);
+    return this.connect(provider).sendTransaction(
+      transaction as TransactionRequest,
+    );
   }
   eth_sendRawTransaction(
     rawTransaction: string,
@@ -208,7 +215,10 @@ export default class EIP155Wallet implements EIP155WalletInterface {
             EIP155_CHAINS[chainId as TEIP155Chain].rpc,
           );
           const signTransaction = request.params[0];
-          const signature = await this.eth_signTransaction(signTransaction, provider);
+          const signature = await this.eth_signTransaction(
+            signTransaction,
+            provider,
+          );
           return formatJsonRpcResult(id, signature);
         } catch (error) {
           console.error(error);

--- a/src/lib/eip155-wallet.ts
+++ b/src/lib/eip155-wallet.ts
@@ -4,6 +4,8 @@ import {
   BaseWallet as BaseEvmWallet,
   TransactionRequest,
   TransactionResponse,
+  JsonRpcTransactionRequest,
+  Transaction,
 } from "ethers";
 
 import {
@@ -52,14 +54,15 @@ export interface EIP155WalletInterface {
     data: any,
   ): Promise<string>;
   [EIP155_METHODS.SignTransaction](
-    transaction: TransactionRequest,
+    transaction: JsonRpcTransactionRequest,
+    provider: JsonRpcProvider,
   ): Promise<string>;
   [EIP155_METHODS.SendTransaction](
-    transaction: TransactionRequest,
+    transaction: JsonRpcTransactionRequest,
     provider: JsonRpcProvider,
   ): Promise<TransactionResponse>;
   [EIP155_METHODS.SendRawTransaction](
-    transaction: TransactionRequest,
+    rawTransaction: string,
     provider: JsonRpcProvider,
   ): Promise<TransactionResponse>;
 }
@@ -91,20 +94,27 @@ export default class EIP155Wallet implements EIP155WalletInterface {
   eth_signTypedData_v4(domain: any, types: any, data: any): Promise<string> {
     return this.eth_signTypedData(domain, types, data);
   }
-  eth_signTransaction(transaction: TransactionRequest): Promise<string> {
-    return this.wallet.signTransaction(transaction);
+  async eth_signTransaction(transaction: JsonRpcTransactionRequest, provider: JsonRpcProvider): Promise<string> {
+    console.log({ transaction });
+
+    // Populate transaction
+    const preparedTransaction = await this.connect(provider).populateTransaction(transaction as TransactionRequest);
+    delete preparedTransaction.from;
+    const txObj = Transaction.from(preparedTransaction);
+
+    return this.wallet.signTransaction(txObj);
   }
   eth_sendTransaction(
-    transaction: TransactionRequest,
+    transaction: JsonRpcTransactionRequest,
     provider: JsonRpcProvider,
   ): Promise<TransactionResponse> {
-    return this.connect(provider).sendTransaction(transaction);
+    return this.connect(provider).sendTransaction(transaction as TransactionRequest);
   }
   eth_sendRawTransaction(
-    transaction: TransactionRequest,
+    rawTransaction: string,
     provider: JsonRpcProvider,
   ): Promise<TransactionResponse> {
-    return this.connect(provider).sendTransaction(transaction);
+    return provider.broadcastTransaction(rawTransaction);
   }
 
   static init({ privateKey }: IInitArgs) {
@@ -169,7 +179,7 @@ export default class EIP155Wallet implements EIP155WalletInterface {
             EIP155_CHAINS[chainId as TEIP155Chain].rpc,
           );
           const sendTransaction = request.params[0];
-          const txResponse = await this.eth_sendTransaction(
+          const txResponse = await this[request.method](
             sendTransaction,
             provider,
           );
@@ -194,8 +204,11 @@ export default class EIP155Wallet implements EIP155WalletInterface {
 
       case EIP155_METHODS.SignTransaction:
         try {
+          const provider = new JsonRpcProvider(
+            EIP155_CHAINS[chainId as TEIP155Chain].rpc,
+          );
           const signTransaction = request.params[0];
-          const signature = await this.eth_signTransaction(signTransaction);
+          const signature = await this.eth_signTransaction(signTransaction, provider);
           return formatJsonRpcResult(id, signature);
         } catch (error) {
           console.error(error);

--- a/src/lib/hip820-wallet.ts
+++ b/src/lib/hip820-wallet.ts
@@ -99,7 +99,11 @@ export class HIP820Wallet implements HIP820WalletInterface {
     const network = chainId.split(":")[1];
     const client = Client.forName(network);
     const provider = _provider ?? new Provider(client);
-    const wallet = new HederaWallet(accountId, PrivateKey.fromStringECDSA(privateKey), provider);
+    const wallet = new HederaWallet(
+      accountId,
+      PrivateKey.fromStringECDSA(privateKey),
+      provider,
+    );
     return new HIP820Wallet(wallet);
   }
 
@@ -252,17 +256,23 @@ export class HIP820Wallet implements HIP820WalletInterface {
   }
 
   // 2. hedera_executeTransaction
-  public async hedera_executeTransaction(id: number, signedTransaction: Transaction): Promise<ExecuteTransactionResult | JsonRpcError> {
+  public async hedera_executeTransaction(
+    id: number,
+    signedTransaction: Transaction,
+  ): Promise<ExecuteTransactionResult | JsonRpcError> {
     try {
       const response = await signedTransaction.executeWithSigner(this.wallet);
       return formatJsonRpcResult(id, response.toJSON());
-    }
-    catch (e) {
+    } catch (e) {
       if (e instanceof PrecheckStatusError) {
         // HIP-820 error format
-        return formatJsonRpcError(id, { code: 9000, message: e.message, data: e.status._code.toString() })
+        return formatJsonRpcError(id, {
+          code: 9000,
+          message: e.message,
+          data: e.status._code.toString(),
+        });
       }
-      return formatJsonRpcError(id, { code: 9000, message: "Unknown Error" })
+      return formatJsonRpcError(id, { code: 9000, message: "Unknown Error" });
     }
   }
   // 3. hedera_signMessage
@@ -291,7 +301,6 @@ export class HIP820Wallet implements HIP820WalletInterface {
      * https://github.com/hashgraph/hedera-sdk-js/blob/c4438cbaa38074d8bfc934dba84e3b430344ed89/src/account/AccountInfo.js#L402
      */
     try {
-
       const queryResult = await body.executeWithSigner(this.wallet);
       let queryResponse = "";
       if (Array.isArray(queryResult)) {
@@ -305,19 +314,25 @@ export class HIP820Wallet implements HIP820WalletInterface {
       return formatJsonRpcResult(id, {
         response: queryResponse,
       });
-    }
-    catch (e) {
+    } catch (e) {
       if (e instanceof PrecheckStatusError) {
         // HIP-820 error format
-        return formatJsonRpcError(id, { code: 9000, message: e.message, data: e.status._code.toString() })
+        return formatJsonRpcError(id, {
+          code: 9000,
+          message: e.message,
+          data: e.status._code.toString(),
+        });
       }
-      return formatJsonRpcError(id, { code: 9000, message: "Unknown Error" })
+      return formatJsonRpcError(id, { code: 9000, message: "Unknown Error" });
     }
   }
 
   // 5. hedera_signAndExecuteTransaction
-  public async hedera_signAndExecuteTransaction(id: number, transaction: Transaction) {
-    console.log({ inputTx: JSON.parse(JSON.stringify(transaction)) })
+  public async hedera_signAndExecuteTransaction(
+    id: number,
+    transaction: Transaction,
+  ) {
+    console.log({ inputTx: JSON.parse(JSON.stringify(transaction)) });
     // check transaction is incomplete (HIP-745)
     if (!transaction.isFrozen()) {
       // set multiple nodeAccountIds and transactionId if not present
@@ -327,17 +342,17 @@ export class HIP820Wallet implements HIP820WalletInterface {
     const signedTransaction = await transaction.signWithSigner(this.wallet);
     try {
       const response = await signedTransaction.executeWithSigner(this.wallet);
-      return formatJsonRpcResult(
-        id,
-        response.toJSON(),
-      );
-    }
-    catch (e) {
+      return formatJsonRpcResult(id, response.toJSON());
+    } catch (e) {
       if (e instanceof PrecheckStatusError) {
         // HIP-820 error format
-        return formatJsonRpcError(id, { code: 9000, message: e.message, data: e.status._code.toString() })
+        return formatJsonRpcError(id, {
+          code: 9000,
+          message: e.message,
+          data: e.status._code.toString(),
+        });
       }
-      return formatJsonRpcError(id, { code: 9000, message: "Unknown Error" })
+      return formatJsonRpcError(id, { code: 9000, message: "Unknown Error" });
     }
   }
 

--- a/src/store/hedera-wallet-provider.tsx
+++ b/src/store/hedera-wallet-provider.tsx
@@ -11,7 +11,7 @@ import {
   HederaJsonRpcMethod,
 } from "@hashgraph/hedera-wallet-connect";
 import { SignClientTypes } from "@walletconnect/types";
-import WalletKit, { IWalletKit } from "@reown/walletkit";
+import WalletKit from "@reown/walletkit";
 import { JsonRpcError, JsonRpcResult } from "@walletconnect/jsonrpc-utils";
 import { buildApprovedNamespaces, getSdkError } from "@walletconnect/utils";
 import { Core } from "@walletconnect/core";
@@ -54,10 +54,10 @@ export default function HederaWalletProvider({ children }: HederaWalletProps) {
   const [isInitialized, setInitialized] = useState(false);
   const [eip155Wallet, setEip155Wallet] = useState<EIP155Wallet>();
   const [hip820Wallet, setHip820Wallet] = useState<HIP820Wallet>();
-  const walletkit = useRef<IWalletKit>();
+  const walletkit = useRef<WalletKit>();
   const [network, setNetwork] = useState<"testnet" | "mainnet">("testnet");
 
-  async function createWalletKit(): Promise<IWalletKit> {
+  async function createWalletKit(): Promise<WalletKit> {
     console.log("Creating WalletKit");
     const core = new Core({
       projectId: import.meta.env.VITE_REOWN_PROJECT_ID,
@@ -73,17 +73,7 @@ export default function HederaWalletProvider({ children }: HederaWalletProps) {
       },
     });
 
-    try {
-      const clientId =
-        await walletkit.engine.signClient.core.crypto.getClientId();
-      console.log("WalletConnect ClientID: ", clientId);
-      return walletkit;
-    } catch (error) {
-      throw new Error(
-        "Failed to set WalletConnect clientId in localStorage: " +
-          (error instanceof Error ? error.message : error),
-      );
-    }
+    return walletkit;
   }
 
   useEffect(() => {
@@ -277,6 +267,7 @@ export default function HederaWalletProvider({ children }: HederaWalletProps) {
     if (!walletkit.current) {
       throw new Error("WalletKit not initialized");
     }
+    
     //https://docs.walletconnect.com/web3wallet/wallet-usage#session-disconnect
     for (const session of Object.values(
       walletkit.current.getActiveSessions(),
@@ -295,6 +286,7 @@ export default function HederaWalletProvider({ children }: HederaWalletProps) {
       });
     }
     setInitialized(false);
+    walletkit.current = undefined;
   }
 
   async function pair(uri: string) {

--- a/src/store/hedera-wallet-provider.tsx
+++ b/src/store/hedera-wallet-provider.tsx
@@ -83,33 +83,36 @@ export default function HederaWalletProvider({ children }: HederaWalletProps) {
     console.log({ hip820Wallet });
   }, [hip820Wallet]);
 
-  const initialize = useCallback(async (
-    accountId: string,
-    privateKey: string,
-    network: "testnet" | "mainnet",
-  ) => {
-    if (isInitialized || walletkit.current) {
-      return;
-    }
-    console.trace("initialize wallets");
-    try {
-      setNetwork(network);
-      const eip155Wallet = EIP155Wallet.init({ privateKey });
-      const hip820Wallet = HIP820Wallet.init({
-        chainId: `hedera:${network}` as HederaChainId,
-        accountId,
-        privateKey,
-      });
-      setEip155Wallet(eip155Wallet);
-      setHip820Wallet(hip820Wallet);
-      walletkit.current = await createWalletKit();
+  const initialize = useCallback(
+    async (
+      accountId: string,
+      privateKey: string,
+      network: "testnet" | "mainnet",
+    ) => {
+      if (isInitialized || walletkit.current) {
+        return;
+      }
+      console.trace("initialize wallets");
+      try {
+        setNetwork(network);
+        const eip155Wallet = EIP155Wallet.init({ privateKey });
+        const hip820Wallet = HIP820Wallet.init({
+          chainId: `hedera:${network}` as HederaChainId,
+          accountId,
+          privateKey,
+        });
+        setEip155Wallet(eip155Wallet);
+        setHip820Wallet(hip820Wallet);
+        walletkit.current = await createWalletKit();
 
-      setInitialized(true);
-    } catch (err: unknown) {
-      console.error("Initialization failed", err);
-      alert(err);
-    }
-  }, [isInitialized]);
+        setInitialized(true);
+      } catch (err: unknown) {
+        console.error("Initialization failed", err);
+        alert(err);
+      }
+    },
+    [isInitialized],
+  );
 
   useEffect(() => {
     if (!walletkit.current) return;
@@ -267,7 +270,7 @@ export default function HederaWalletProvider({ children }: HederaWalletProps) {
     if (!walletkit.current) {
       throw new Error("WalletKit not initialized");
     }
-    
+
     //https://docs.walletconnect.com/web3wallet/wallet-usage#session-disconnect
     for (const session of Object.values(
       walletkit.current.getActiveSessions(),


### PR DESCRIPTION
- Added correct exception handling for hedera_signAndExecuteQuery.
- Fixes for disconnect.

ED25519 issue:
Since EVM address is derived from public ECDSA key, currently wallet works only with ECDSA wallets. [hedera-json-rpc-relay](https://github.com/hashgraph/hedera-json-rpc-relay) repository also uses ECDSA wallets in tests to sign transactions and send them to JSON-RPC, although ED25519 is used for operator and recipient wallets. 
Direct evm replacing using long-zero alias does not work because ethers.js checks the `from` filed <-> signer evm address based on its key. At the same time ethers.js performs a lot of operations under the hood, such as getting nonce, RLP encoding, gas price, transaction status polling, etc, so no quick way to replace it for signing and sending a transaction has been found. The same applies to EIP-712 signature (eth_signTypedData), which assumes ECDSA signature. [Hedera documentation](https://docs.hedera.com/hedera/core-concepts/smart-contracts/understanding-hederas-evm-differences-and-compatibility/for-evm-developers-migrating-to-hedera/accounts-signature-verification-and-keys-ecdsa-vs.-ed25519) gives workaround instructions only for smart contracts within the framework of EVM compatibility .

If you have any suggestions for adding support for ED25519 or regarding changes to the PR, let me know, thanks